### PR TITLE
Fix folder argument

### DIFF
--- a/Commands/EntriesCommand.php
+++ b/Commands/EntriesCommand.php
@@ -6,6 +6,7 @@ use Statamic\API\File;
 use Statamic\API\YAML;
 use Statamic\API\Config;
 use Statamic\API\Content;
+use Statamic\API\Collection;
 use Illuminate\Console\Command;
 
 class EntriesCommand extends Command
@@ -36,6 +37,10 @@ class EntriesCommand extends Command
         $folder = ($this->argument('folder'))
             ? $this->argument('folder')
             : $this->choice('In which collection would you like them?', Content::collectionNames());
+
+        if (! Collection::handleExists($folder)) {
+            return $this->error("Collection '{$folder}' doesn't exist.");
+        }
 
         $count = ($this->argument('count'))
             ? $this->argument('count')

--- a/Commands/EntriesCommand.php
+++ b/Commands/EntriesCommand.php
@@ -33,13 +33,13 @@ class EntriesCommand extends Command
      */
     public function handle()
     {
+        $folder = ($this->argument('folder'))
+            ? $this->argument('folder')
+            : $this->choice('In which collection would you like them?', Content::collectionNames());
+
         $count = ($this->argument('count'))
             ? $this->argument('count')
             : $this->ask('How many entries do you want?');
-
-        $collections = Content::collectionNames();
-
-        $folder = $this->choice('In which collection would you like them?', $collections);
 
         $this->makeTheGoodStuff($count, $folder);
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 name: Overload
-version: 1.0
+version: 1.1
 description: Creates masses of test content to aid in load testing.
 developer: Statamic
 developer_url: http://statamic.com


### PR DESCRIPTION
This lovely line in the README `php please overload:entries [<folder>] [<count>]` doesn't actually work because the `folder` argument wasn't being picked up inside the command. This fixes that. Yay!